### PR TITLE
linter fixes for the csp-fix branch

### DIFF
--- a/pretix_eth/forms.py
+++ b/pretix_eth/forms.py
@@ -22,8 +22,8 @@ class WalletAddressTxtFile(ExtFileField):
 
             # Strip leading and trailing whitespace on each line; filter empty
             # lines; filter comments
-            lines = [l.strip() for l in lines if l.strip()]
-            lines = [l for l in lines if not COMMENT_RE.match(l)]
+            lines = [line.strip() for line in lines if line.strip()]
+            lines = [line for line in lines if not COMMENT_RE.match(line)]
 
             if len(lines) == 0:
                 raise forms.ValidationError(_("File contains no addresses"))

--- a/pretix_eth/management/commands/confirm_payments.py
+++ b/pretix_eth/management/commands/confirm_payments.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                     if eth_amount < expected_amount:
                         logger.warning(f'  * Expected payment of at least {expected_amount} ETH')  # noqa: E501
                         logger.warning(f'  * Given payment was {eth_amount} ETH')  # noqa: E501
-                        logger.warning(f'  * Skipping')
+                        logger.warning(f'  * Skipping')  # noqa: F541
                         continue
                 elif expected_currency_type == 'DAI':
                     if eth_amount > 0:
@@ -100,7 +100,7 @@ class Command(BaseCommand):
                     if token_amount < expected_amount:
                         logger.warning(f'  * Expected payment of at least {expected_amount} DAI')  # noqa: E501
                         logger.warning(f'  * Given payment was {token_amount} DAI')  # noqa: E501
-                        logger.warning(f'  * Skipping')
+                        logger.warning(f'  * Skipping')  # noqa: F541
                         continue
 
                 if no_dry_run:


### PR DESCRIPTION
### What was wrong?

linter errors `F541` and `E741`

### How was it fixed?

one fixed, one ignored

#### Cute Animal Picture

![Cute animal picture](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/lionel-animals-to-follow-on-instagram-1568319926.jpg?crop=1.00xw:0.401xh;0,0.282xh&resize=980:*)
